### PR TITLE
Make no-regex mode default

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,10 @@
+## 0.6
+Features:
++ Make no_regex default, and instead expose attribute regex
+
+Fixes:
++ Fix no_regex $ escaping
+
 ### 0.5.3
 + Implement `Error` trait for `reformation::Error`. (credit: nertpinx)
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ use reformation::Reformation;
 
 #[derive(Reformation, Eq, PartialEq, Debug)]
 enum Ant{
-    #[reformation(r"Queen\({}\)")]
+    #[reformation(r"Queen({})")]
     Queen(String),
-    #[reformation(r"Worker\({}\)")]
+    #[reformation(r"Worker({})")]
     Worker(i32),
     #[reformation(r"Warrior")]
     Warrior
@@ -94,15 +94,16 @@ use reformation::Reformation;
 #[derive(Reformation, Eq, PartialEq, Debug)]
 #[reformation("{a} {b}")]
 struct InPlace<'a, 'b>{
-    #[reformation("[a-z]*")]
+    #[reformation("[a-z]*", regex=true)]
     a: &'a str,
-    #[reformation("[a-z]*")]
+    #[reformation("[a-z]*", regex=true)]
     b: &'b str,
 }
 
 fn main(){
     // Then parsed from &'x str value will have type
     // InPlace<'x, 'x>
+    println!("{}", InPlace::regex_str());
     let inplace = InPlace::parse("aval bval").unwrap();
     assert_eq!(inplace, InPlace{a: "aval", b: "bval"})
 }
@@ -114,7 +115,7 @@ Order, in which modes are specified does not matter.
 
 #### fromstr
 
-Generate implementation of `FromStr` trait. 
+Generate implementation of `FromStr` trait.
 
 Not compatible with lifetime annotated structs.
 
@@ -144,23 +145,23 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 ```
 
-#### no_regex
+#### regex
 
-Makes format string behave as regular string (in contrast with being regular expression),
-by escaping all special regex characters.
+Makes format string behave as regular expression
+by turning off escaping of all special regex characters.
 
 ```rust
 use reformation::Reformation;
 
 #[derive(Reformation, Debug)]
-#[reformation("Vec{{{x}, {y}}}", no_regex=true)]
+#[reformation(r"Vec\{{{x}, *{y}\}}", regex=true)]
 struct Vec{
     x: i32,
     y: i32,
 }
 
 fn main(){
-    let v= Vec::parse("Vec{-1, 1}").unwrap();
+    let v = Vec::parse("Vec{-1,    1}").unwrap();
     assert_eq!(v.x, -1);
     assert_eq!(v.y, 1);
 }
@@ -171,11 +172,12 @@ fn main(){
 Allow arbitrary number of spaces after separators: ',', ';', ':'. For separator to be recognized
 as slack, it must be followed by at least one space in format string.
 
+
 ```rust
 use reformation::Reformation;
 
 #[derive(Reformation, Debug)]
-#[reformation(r"Vec\{{{x}, {y}\}}", slack=true)]
+#[reformation(r"Vec{{{x}, {y}}}", slack=true)]
 struct Vec{
     x: i32,
     y: i32,

--- a/reformation/examples/derive.rs
+++ b/reformation/examples/derive.rs
@@ -10,11 +10,20 @@ struct Vec {
     z: f32,
 }
 
+// By default, regular expression items are escaped
+#[derive(Debug, Reformation)]
+#[reformation(r"(\|)({left_eye}_{right_eye})(|/)")]
+struct Crab {
+    left_eye: String,
+    right_eye: String,
+}
+
+// But regular expressions can be enabled by providing `regex=true` attribute
 // note that capture group (,|;) is replaced with non-capturing (:?,|;) in order
 // to avoid accidental break of expression. Note that named capture groups
 // (?P<name>expr) will still cause logical error and hopefully panic.
 #[derive(Debug, Reformation)]
-#[reformation(r"Rect\{{{a}(,|;)\s+{b}\}}")]
+#[reformation(r"Rect\{{{a}(,|;)\s+{b}\}}", regex = true)]
 struct Rect {
     a: Vec,
     b: Vec,
@@ -22,15 +31,6 @@ struct Rect {
     // Note what zero does not appear in format string, but
     // initialized from `Default` trait implementation
     zero: usize,
-}
-
-// One may choose to use plain format syntax (with no regular expressions)
-// by providing `no_regex=true` mode
-#[derive(Debug, Reformation)]
-#[reformation(r"(\|)({left_eye}_{right_eye})(|/)", no_regex = true)]
-struct Crab {
-    left_eye: String,
-    right_eye: String,
 }
 
 #[derive(Debug, Reformation)]

--- a/reformation/examples/enum_.rs
+++ b/reformation/examples/enum_.rs
@@ -6,7 +6,7 @@ enum Color {
     Red,
     #[reformation("green")]
     Green,
-    #[reformation(r"grey\({}\)")]
+    #[reformation(r"grey({})")]
     Grey(i32),
     #[reformation("yellow")]
     Yellow,
@@ -15,7 +15,7 @@ enum Color {
 }
 
 #[derive(Reformation, Debug, PartialEq)]
-#[reformation(no_regex = true)]
+#[reformation()]
 enum Superman {
     #[reformation("Bird({})")]
     Bird(f32),
@@ -24,7 +24,7 @@ enum Superman {
 }
 
 #[derive(Reformation, Debug, PartialEq)]
-#[reformation(no_regex = true, slack = true)]
+#[reformation(slack = true)]
 enum MiniList {
     #[reformation("[]")]
     Zero,

--- a/reformation/src/lib.rs
+++ b/reformation/src/lib.rs
@@ -63,9 +63,9 @@
 //!
 //! #[derive(Reformation, Eq, PartialEq, Debug)]
 //! enum Ant{
-//!     #[reformation(r"Queen\({}\)")]
+//!     #[reformation(r"Queen({})")]
 //!     Queen(String),
-//!     #[reformation(r"Worker\({}\)")]
+//!     #[reformation(r"Worker({})")]
 //!     Worker(i32),
 //!     #[reformation(r"Warrior")]
 //!     Warrior
@@ -90,9 +90,9 @@
 //! #[derive(Reformation, Eq, PartialEq, Debug)]
 //! #[reformation("{a} {b}")]
 //! struct InPlace<'a, 'b>{
-//!     #[reformation("[a-z]*")]
+//!     #[reformation("[a-z]*", regex=true)]
 //!     a: &'a str,
-//!     #[reformation("[a-z]*")]
+//!     #[reformation("[a-z]*", regex=true)]
 //!     b: &'b str,
 //! }
 //!
@@ -111,7 +111,7 @@
 //!
 //! ### fromstr
 //!
-//! Generate implementation of `FromStr` trait. 
+//! Generate implementation of `FromStr` trait.
 //!
 //! Not compatible with lifetime annotated structs.
 //!
@@ -141,23 +141,23 @@
 //! }
 //! ```
 //!
-//! ### no_regex
+//! ### regex
 //!
-//! Makes format string behave as regular string (in contrast with being regular expression),
-//! by escaping all special regex characters.
+//! Makes format string behave as regular expression
+//! by turning off escaping of all special regex characters.
 //!
 //! ```
 //! use reformation::Reformation;
 //!
 //! #[derive(Reformation, Debug)]
-//! #[reformation("Vec{{{x}, {y}}}", no_regex=true)]
+//! #[reformation(r"Vec\{{{x}, *{y}\}}", regex=true)]
 //! struct Vec{
 //!     x: i32,
 //!     y: i32,
 //! }
 //!
 //! fn main(){
-//!     let v= Vec::parse("Vec{-1, 1}").unwrap();
+//!     let v = Vec::parse("Vec{-1,    1}").unwrap();
 //!     assert_eq!(v.x, -1);
 //!     assert_eq!(v.y, 1);
 //! }
@@ -173,7 +173,7 @@
 //! use reformation::Reformation;
 //!
 //! #[derive(Reformation, Debug)]
-//! #[reformation(r"Vec\{{{x}, {y}\}}", slack=true)]
+//! #[reformation(r"Vec{{{x}, {y}}}", slack=true)]
 //! struct Vec{
 //!     x: i32,
 //!     y: i32,
@@ -190,7 +190,7 @@
 //! }
 //! ```
 
-#![cfg_attr(feature="containers", feature(const_generics))]
+#![cfg_attr(feature = "containers", feature(const_generics))]
 
 #[macro_use]
 extern crate derive_more;
@@ -201,7 +201,7 @@ pub use regex::{CaptureLocations, Error as RegexError, Regex};
 use std::collections::HashMap;
 use std::sync::RwLock;
 
-#[cfg(feature="containers")]
+#[cfg(feature = "containers")]
 pub mod containers;
 
 /// Declares how object can be parsed from `&'a str`
@@ -275,8 +275,8 @@ pub struct GenericStaticStr<T: 'static> {
     map: RwLock<CallMap<T>>,
 }
 
-impl<T: 'static> Default for GenericStaticStr<T>{
-    fn default() -> Self{
+impl<T: 'static> Default for GenericStaticStr<T> {
+    fn default() -> Self {
         Self::new()
     }
 }

--- a/reformation/tests/enum.rs
+++ b/reformation/tests/enum.rs
@@ -12,7 +12,7 @@ enum A {
 enum B {
     #[reformation("{}")]
     One(u8),
-    #[reformation("{}..{}", no_regex = true)]
+    #[reformation("{}..{}")]
     Pair(u8, u8),
 
     // variant that cannot be produced by parse function
@@ -41,8 +41,7 @@ fn test_enum_separation() -> Result<(), reformation::Error> {
 }
 
 #[derive(Reformation)]
-#[reformation(no_regex=true)]
-enum LifetimeInEnum<'a>{
+enum LifetimeInEnum<'a> {
     #[reformation("A")]
     A,
     #[reformation("B({})")]
@@ -50,8 +49,5 @@ enum LifetimeInEnum<'a>{
     #[reformation("C({})")]
     C(&'a str),
     #[reformation("D({_value})")]
-    D {
-        _value: &'a str
-    },
+    D { _value: &'a str },
 }
-

--- a/reformation/tests/struct.rs
+++ b/reformation/tests/struct.rs
@@ -1,7 +1,7 @@
 use reformation::{Error, ParseOverride, Reformation};
 
 #[derive(Debug, Reformation, PartialEq)]
-#[reformation(r"Vec\{{{x}, {y}, {z}\}}", slack = true)]
+#[reformation(r"Vec{{{x}, {y}, {z}}}", slack = true)]
 struct Vect {
     x: f32,
     y: f32,
@@ -23,7 +23,7 @@ fn test_vec() {
 // to avoid accidental break of expression. Note that named capture groups
 // (?P<name>expr) will still cause logical error and hopefully panic.
 #[derive(Debug, Reformation, PartialEq)]
-#[reformation(r"Rect\{{{a}(,|;)\s+{b}\}}")]
+#[reformation(r"Rect\{{{a}(,|;)\s+{b}\}}", regex = true)]
 struct Rect {
     a: Vect,
     b: Vect,
@@ -118,10 +118,10 @@ fn test_generic() {
 #[derive(Reformation, PartialEq, Debug)]
 #[reformation("{a} {b}")]
 struct Override {
-    #[reformation(r".")]
+    #[reformation(r".", regex = true)]
     a: i32,
 
-    #[reformation(r"\d( \d)*")]
+    #[reformation(r"\d( \d)*", regex = true)]
     b: VecWrapper,
 }
 
@@ -191,7 +191,7 @@ fn test_fromstr() {
 }
 
 #[derive(Reformation, Debug, PartialEq)]
-#[reformation("$", no_regex = true)]
+#[reformation("$")]
 struct Dollar;
 
 #[test]

--- a/reformation_derive/src/reformation_attribute.rs
+++ b/reformation_derive/src/reformation_attribute.rs
@@ -13,7 +13,7 @@ pub struct ReformationAttribute {
     pub regex_string: Option<String>,
 
     pub slack: bool,
-    pub no_regex: bool,
+    pub regex: bool,
     pub fromstr: bool,
 }
 
@@ -23,7 +23,7 @@ impl ReformationAttribute {
             span,
             regex_string: None,
             slack: false,
-            no_regex: false,
+            regex: false,
             fromstr: false,
         }
     }
@@ -38,16 +38,16 @@ impl ReformationAttribute {
             regex_string: s,
             fromstr: false, // Only makes sence on top level #TODO
             slack: other.slack | self.slack,
-            no_regex: other.no_regex | self.no_regex,
+            regex: other.regex | self.regex,
         }
     }
 
     pub fn substr_mode(&self) -> impl Fn(&str) -> String + '_ {
         move |s| {
-            let s = if self.no_regex {
-                escape(s)
-            } else {
+            let s = if self.regex {
                 no_capturing_groups(s)
+            } else {
+                escape(s)
             };
             if self.slack {
                 slack(&s)
@@ -123,8 +123,8 @@ impl ReformationAttribute {
     fn apply(&mut self, mode: Mode) -> syn::Result<()> {
         match mode {
             Mode::BoolParam(ident) => match ident.to_string().as_str() {
-                "no_regex" => {
-                    self.no_regex = true;
+                "regex" => {
+                    self.regex = true;
                     Ok(())
                 }
                 "slack" => {


### PR DESCRIPTION
Instead of specifying that special symbols from regular expression must be escaped, escape them by default.

Then regular expressions are required by user, they could enable them via `regex=true` attribute.